### PR TITLE
fix: empty descriptions keys in assets

### DIFF
--- a/tronpy/tron.py
+++ b/tronpy/tron.py
@@ -804,7 +804,10 @@ class Tron(object):
                 asset["abbr"] = bytes.fromhex(asset["abbr"]).decode()
             else:
                 asset["abbr"] = ""
-            asset["description"] = bytes.fromhex(asset["description"]).decode("utf8", "replace")
+            if "description" in asset:
+                asset["description"] = bytes.fromhex(asset["description"]).decode("utf8", "replace")
+            else:
+                asset["description"] = ""
             asset["url"] = bytes.fromhex(asset["url"]).decode()
         return assets
 


### PR DESCRIPTION
In some cases for some assets code `client.list_assets()` where `client = Tron(network='nile')` raised an Error:
```
File "/Users/vyacheslav/TronTest/venv/lib/python3.9/site-packages/tronpy/tron.py", line 763, in list_assets
    asset["description"] = bytes.fromhex(asset["description"]).decode("utf8", "replace")
KeyError: 'description'

```
