### PR TITLE
fix: httpx dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     'eth_abi>=2.1.1,<3.0.0',
     'pycryptodome>=3.9.7,<4.0.0',
     'requests>=2.23.0,<3.0.0',
-    'httpx==0.16.1',
+    'httpx>=0.16.1,<1.0.0',
 ]
 
 setup_kwargs = {


### PR DESCRIPTION
Currently `tronpy` conflicts with other packages such as `xrpl-py` because of `httpx==0.16.1`.
It would be nice to loosen the version requirement like other dependencies.