### PR TITLE
feat: add support of wallet/getcontractinfo

### DIFF
--- a/tronpy/async_tron.py
+++ b/tronpy/async_tron.py
@@ -1011,6 +1011,18 @@ class AsyncTron:
         )
         return cntr
 
+    async def get_contract_info(self, addr: TAddress) -> dict:
+        """Queries a contract's information from the blockchain"""
+        addr = keys.to_base58check_address(addr)
+        info = await self.provider.make_request("wallet/getcontractinfo", {"value": addr, "visible": True})
+
+        try:
+            self._handle_api_error(info)
+        except ApiError:
+            raise AddressNotFound("contract address not found")
+
+        return info
+
     async def get_contract_as_shielded_trc20(self, addr: TAddress) -> ShieldedTRC20:
         """Get a Shielded TRC20 Contract object."""
         contract = await self.get_contract(addr)

--- a/tronpy/tron.py
+++ b/tronpy/tron.py
@@ -986,7 +986,7 @@ class Tron:
         )
         return cntr
 
-     def get_contract_info(self, addr: TAddress) -> dict:
+    def get_contract_info(self, addr: TAddress) -> dict:
         """Queries a contract's information from the blockchain"""
         addr = keys.to_base58check_address(addr)
         info = self.provider.make_request("wallet/getcontractinfo", {"value": addr, "visible": True})

--- a/tronpy/tron.py
+++ b/tronpy/tron.py
@@ -986,6 +986,18 @@ class Tron:
         )
         return cntr
 
+     def get_contract_info(self, addr: TAddress) -> dict:
+        """Queries a contract's information from the blockchain"""
+        addr = keys.to_base58check_address(addr)
+        info = self.provider.make_request("wallet/getcontractinfo", {"value": addr, "visible": True})
+
+        try:
+            self._handle_api_error(info)
+        except ApiError:
+            raise AddressNotFound("contract address not found")
+
+        return info
+
     def get_contract_as_shielded_trc20(self, addr: TAddress) -> ShieldedTRC20:
         """Get a Shielded TRC20 Contract object."""
         contract = self.get_contract(addr)


### PR DESCRIPTION
The `wallet/getcontractinfo` response, specifically `energy_factor` field, can be used in calculation to predict contract method energy use. 

So, I think the get_contract_info method should be present in the client. 